### PR TITLE
feat: improve mobile navigation and responsiveness

### DIFF
--- a/app/(app)/agents/new/page.tsx
+++ b/app/(app)/agents/new/page.tsx
@@ -177,8 +177,8 @@ export default function NewAgentPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-3xl mx-auto">
-        <div className="flex items-center mb-8">
-          <Link href="/agents" className="mr-4">
+        <div className="mb-8 flex flex-wrap items-center gap-3">
+          <Link href="/agents">
             <Button variant="ghost" size="icon">
               <ArrowLeft className="h-4 w-4" />
             </Button>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/supabase/server";
 import { redirect } from "next/navigation";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/app-sidebar";
+import { AppMobileNav } from "@/components/layout/app-mobile-nav";
 import { OnboardingProvider } from "@/hooks/useOnboarding";
 import { TutorialOverlay } from "@/components/onboarding/TutorialOverlay";
 import { WelcomeModal } from "@/components/onboarding/WelcomeModal";
@@ -30,9 +31,12 @@ export default async function AuthenticatedLayout({
       <SidebarProvider>
         <AppSidebar user={user} />
         <SidebarInset>
+          <AppMobileNav />
           <TutorialOverlay>
-            {children}
-            <WelcomeModal />
+            <div className="flex flex-1 flex-col pb-24 md:pb-0">
+              {children}
+              <WelcomeModal />
+            </div>
           </TutorialOverlay>
         </SidebarInset>
       </SidebarProvider>

--- a/app/(app)/tools/page.tsx
+++ b/app/(app)/tools/page.tsx
@@ -287,11 +287,12 @@ export default function ToolsPage() {
         </div>
 
         {/* Filter Buttons */}
-        <div className="flex justify-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
           <Button
             variant={serverFilter === "all" ? "default" : "outline"}
             size="sm"
             onClick={() => setServerFilter("all")}
+            className="w-full sm:w-auto"
           >
             All Servers
           </Button>
@@ -299,6 +300,7 @@ export default function ToolsPage() {
             variant={serverFilter === "official" ? "default" : "outline"}
             size="sm"
             onClick={() => setServerFilter("official")}
+            className="w-full sm:w-auto"
           >
             Official
           </Button>
@@ -306,6 +308,7 @@ export default function ToolsPage() {
             variant={serverFilter === "smithery" ? "default" : "outline"}
             size="sm"
             onClick={() => setServerFilter("smithery")}
+            className="w-full sm:w-auto"
           >
             Smithery
           </Button>
@@ -363,7 +366,7 @@ export default function ToolsPage() {
       
       {/* Enhanced Pagination */}
       {totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-8">
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
           {/* First Page */}
           <Button
             variant="outline"
@@ -382,13 +385,14 @@ export default function ToolsPage() {
             onClick={() => handlePageChange(page - 1)}
             disabled={page === 1}
             title="Previous page"
+            className="gap-1"
           >
             <ChevronLeft className="h-4 w-4" />
             Previous
           </Button>
 
           {/* Page Numbers */}
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-center gap-2">
             {totalPages <= 7 ? (
               // Show all pages if 7 or fewer
               [...Array(totalPages)].map((_, i) => (
@@ -416,7 +420,7 @@ export default function ToolsPage() {
                 </Button>
                 
                 {/* Show ellipsis if current page is far from start */}
-                {page > 4 && <span className="px-2">...</span>}
+                {page > 4 && <span className="px-2 text-muted-foreground">...</span>}
                 
                 {/* Show pages around current page */}
                 {[...Array(5)].map((_, i) => {
@@ -436,7 +440,7 @@ export default function ToolsPage() {
                 })}
                 
                 {/* Show ellipsis if current page is far from end */}
-                {page < totalPages - 3 && <span className="px-2">...</span>}
+                {page < totalPages - 3 && <span className="px-2 text-muted-foreground">...</span>}
                 
                 {/* Always show last page */}
                 <Button
@@ -458,6 +462,7 @@ export default function ToolsPage() {
             onClick={() => handlePageChange(page + 1)}
             disabled={page === totalPages}
             title="Next page"
+            className="gap-1"
           >
             Next
             <ChevronRight className="h-4 w-4" />

--- a/components/agents/AgentHeader.tsx
+++ b/components/agents/AgentHeader.tsx
@@ -6,10 +6,10 @@ import { PlusCircle } from "lucide-react";
 
 export function AgentHeader() {
   return (
-    <div className="flex justify-between items-center mb-8">
+    <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <h1 className="text-2xl font-bold">My Agents</h1>
-      <Link href="/agents/new">
-        <Button>
+      <Link href="/agents/new" className="w-full sm:w-auto">
+        <Button className="w-full sm:w-auto justify-center">
           <PlusCircle className="mr-2" />
           Create Agent
         </Button>

--- a/components/layout/app-mobile-nav.tsx
+++ b/components/layout/app-mobile-nav.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Bot, Hammer, Home, Plus, Settings2 } from "lucide-react"
+
+import { SidebarTrigger } from "@/components/ui/sidebar"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const mobileNavItems = [
+  {
+    title: "Dashboard",
+    href: "/dashboard",
+    icon: Home,
+  },
+  {
+    title: "Agents",
+    href: "/agents",
+    icon: Bot,
+  },
+  {
+    title: "Tools",
+    href: "/tools",
+    icon: Hammer,
+  },
+  {
+    title: "Settings",
+    href: "/settings",
+    icon: Settings2,
+  },
+] as const
+
+export function AppMobileNav() {
+  const pathname = usePathname() || ""
+
+  const isActive = (href: string) => {
+    if (href === "/dashboard") {
+      return pathname === href
+    }
+    return pathname === href || pathname.startsWith(`${href}/`)
+  }
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 flex items-center gap-3 border-b bg-background px-4 py-3 md:hidden">
+        <SidebarTrigger className="h-10 w-10 rounded-md border border-border" />
+        <Link href="/dashboard" className="flex flex-1 items-center gap-2">
+          <Image
+            src="/images/AffinityBots-Icon-Dark-250px.png"
+            alt="AffinityBots"
+            width={28}
+            height={28}
+            className="h-7 w-7 rounded"
+          />
+          <span className="text-base font-semibold">AffinityBots</span>
+        </Link>
+        <Link href="/agents/new">
+          <Button size="sm" className="gap-2 px-3">
+            <Plus className="h-4 w-4" />
+            <span>Create</span>
+          </Button>
+        </Link>
+      </header>
+      <nav className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/60 md:hidden" aria-label="Primary">
+        <div className="mx-auto flex max-w-md items-center justify-between px-4 py-2">
+          {mobileNavItems.map((item) => {
+            const Icon = item.icon
+            const active = isActive(item.href)
+            return (
+              <Link
+                key={item.title}
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex flex-1 flex-col items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                  active ? "text-primary" : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span>{item.title}</span>
+              </Link>
+            )
+          })}
+        </div>
+      </nav>
+    </>
+  )
+}

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Home, Bot, Sliders, Hammer, Play, TestTubeDiagonal } from "lucide-react";
+import { appNavigation } from "@/components/layout/nav-config";
 
 import { NavMain } from "@/components/layout/nav-main";
 import { NavUser } from "@/components/layout/nav-user";
@@ -17,67 +17,6 @@ import {
 import Image from "next/image";
 import { ResetOnboarding } from "@/components/onboarding/ResetOnboarding";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
-
-// Navigation data structure
-const data = {
-  navMain: [
-    {
-      title: "Dashboard",
-      url: "/dashboard",
-      icon: Home,
-    },
-    {
-      title: "Agents",
-      url: "/agents",
-      icon: Bot,
-      items: [
-        {
-          title: "My Agents",
-          url: "/agents",
-        },
-        {
-          title: "Create Agent",
-          url: "/agents/new",
-        },
-      ],
-    },
-    {
-      title: "Tools",
-      url: "/tools",
-      icon: Hammer,
-      items: [
-        {
-          title: "All Tools",
-          url: "/tools",
-        },
-        {
-          title: "Configured Tools",
-          url: "/tools/configured",
-        },
-      ],
-    },
-    {
-      title: "Workflows",
-      url: "/workflows",
-      icon: Sliders,
-      items: [
-        {
-          title: "My Workflows",
-          url: "/workflows",
-        },
-        {
-          title: "Create Workflow",
-          url: "/workflows/new",
-        },
-      ],
-    },
-    {
-      title: "Playground (Coming Soon)",
-      url: "/playground/playground-coming-soon",
-      icon: TestTubeDiagonal,
-    },
-  ],
-};
 
 interface User {
   name?: string;
@@ -117,7 +56,7 @@ export function AppSidebar({
         </div>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain items={appNavigation} />
       </SidebarContent>
       <SidebarFooter>
         <div className="px-2 py-2 space-y-2 group-data-[collapsible=icon]:hidden">

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -1,0 +1,69 @@
+import { Bot, Hammer, Home, Sliders, TestTubeDiagonal, type LucideIcon } from "lucide-react"
+
+export interface AppNavItem {
+  title: string
+  url: string
+  icon?: LucideIcon
+  items?: {
+    title: string
+    url: string
+  }[]
+}
+
+export const appNavigation: AppNavItem[] = [
+  {
+    title: "Dashboard",
+    url: "/dashboard",
+    icon: Home,
+  },
+  {
+    title: "Agents",
+    url: "/agents",
+    icon: Bot,
+    items: [
+      {
+        title: "My Agents",
+        url: "/agents",
+      },
+      {
+        title: "Create Agent",
+        url: "/agents/new",
+      },
+    ],
+  },
+  {
+    title: "Tools",
+    url: "/tools",
+    icon: Hammer,
+    items: [
+      {
+        title: "All Tools",
+        url: "/tools",
+      },
+      {
+        title: "Configured Tools",
+        url: "/tools/configured",
+      },
+    ],
+  },
+  {
+    title: "Workflows",
+    url: "/workflows",
+    icon: Sliders,
+    items: [
+      {
+        title: "My Workflows",
+        url: "/workflows",
+      },
+      {
+        title: "Create Workflow",
+        url: "/workflows/new",
+      },
+    ],
+  },
+  {
+    title: "Playground (Coming Soon)",
+    url: "/playground/playground-coming-soon",
+    icon: TestTubeDiagonal,
+  },
+]

--- a/components/layout/nav-main.tsx
+++ b/components/layout/nav-main.tsx
@@ -34,11 +34,17 @@ interface NavItem {
 
 export function NavMain({ items }: { items: NavItem[] }) {
   const pathname = usePathname() || ''
-  const { state } = useSidebar()
+  const { state, isMobile, setOpenMobile } = useSidebar()
   const isCollapsed = state === 'collapsed'
 
   const isActiveLink = (url: string) => {
     return pathname === url || pathname.startsWith(`${url}/`)
+  }
+
+  const handleNavigate = () => {
+    if (isMobile) {
+      setOpenMobile(false)
+    }
   }
 
   return (
@@ -49,7 +55,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
           isCollapsed && item.items ? (
             // When collapsed, clicking parent should go to its main page
             <SidebarMenuItem key={item.title} data-tutorial={item.title === "Tools" ? "tools-sidebar" : undefined}>
-              <Link href={item.url}>
+              <Link href={item.url} onClick={handleNavigate}>
                 <SidebarMenuButton
                   tooltip={item.title}
                   className={isActiveLink(item.url) ? 'bg-accent' : ''}
@@ -76,7 +82,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
                 ) : (
-                  <Link href={item.url}>
+                  <Link href={item.url} onClick={handleNavigate}>
                     <SidebarMenuButton
                       tooltip={item.title}
                       className={isActiveLink(item.url) ? 'bg-accent' : ''}
@@ -95,7 +101,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
                             asChild
                             className={isActiveLink(subItem.url) ? 'bg-accent' : ''}
                           >
-                            <Link href={subItem.url}>
+                            <Link href={subItem.url} onClick={handleNavigate}>
                               <span>{subItem.title}</span>
                             </Link>
                           </SidebarMenuSubButton>


### PR DESCRIPTION
## Summary
- add a dedicated mobile header and bottom navigation so core app areas are easy to reach on small screens
- centralize the navigation config and make the sidebar close automatically after selecting a link on mobile
- tweak agent creation and tools listing layouts to better wrap and align controls on narrow viewports

## Testing
- pnpm run lint *(fails: repository already has numerous pre-existing lint errors for no-explicit-any, unused vars, etc.)*
- pnpm run build *(fails: Next.js could not download the Inter font in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48de64a048331b0625f93ce53c7fe