### PR TITLE
fix: enable mobile task configuration

### DIFF
--- a/components/workflows/WorkflowMobileWizard.tsx
+++ b/components/workflows/WorkflowMobileWizard.tsx
@@ -1,0 +1,234 @@
+"use client"
+
+import { Edge } from "reactflow"
+import { WorkflowNode } from "@/types/workflow"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+
+interface WorkflowMobileWizardProps {
+  nodes: WorkflowNode[]
+  edges: Edge[]
+  onAddTrigger: () => void
+  onAddTask: (sourceNodeId: string) => void
+  onAssignAgent: (taskId: string) => void
+  onConfigureTask: (taskId: string) => void
+  onConfigureTrigger: (triggerId: string) => void
+}
+
+const getInitials = (name?: string) => {
+  if (!name) return "?"
+  return name
+    .split(" ")
+    .map((part) => part.charAt(0))
+    .join("")
+    .slice(0, 2)
+    .toUpperCase()
+}
+
+export function WorkflowMobileWizard({
+  nodes,
+  edges,
+  onAddTrigger,
+  onAddTask,
+  onAssignAgent,
+  onConfigureTask,
+  onConfigureTrigger,
+}: WorkflowMobileWizardProps) {
+  const triggerNodes = nodes.filter((node) => node.type === "trigger")
+  const taskNodes = nodes.filter((node) => node.type === "task")
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]))
+
+  const buildSequence = (startId: string) => {
+    const sequence: WorkflowNode[] = []
+    let currentId: string | null = startId
+    const visited = new Set<string>()
+
+    while (currentId && !visited.has(currentId)) {
+      const current = nodeMap.get(currentId)
+      if (!current) break
+      sequence.push(current)
+      visited.add(currentId)
+
+      const outgoing = edges.find((edge) => edge.source === currentId)
+      if (!outgoing) break
+      currentId = outgoing.target
+    }
+
+    return sequence
+  }
+
+  const sequences = triggerNodes.map((trigger) => buildSequence(trigger.id))
+  const visitedTaskIds = new Set(
+    sequences.flat().filter((node) => node.type === "task").map((node) => node.id)
+  )
+  const looseTasks = taskNodes.filter((task) => !visitedTaskIds.has(task.id))
+
+  const renderTriggerCard = (triggerNode: WorkflowNode) => {
+    const data = triggerNode.data as any
+    return (
+      <Card key={triggerNode.id} className="border border-primary/20">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <Badge variant="secondary" className="uppercase">Trigger</Badge>
+              <CardTitle className="mt-2 text-lg">{data?.name || "Workflow trigger"}</CardTitle>
+            </div>
+            <Badge variant={data?.hasConnectedTask ? "default" : "outline"}>
+              {data?.trigger_type || "Custom"}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            {data?.description || "Configure when this workflow should start."}
+          </p>
+          <div className="flex flex-col gap-2">
+            <Button variant="default" onClick={() => onConfigureTrigger(data?.trigger_id)}>
+              Configure trigger
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => onAddTask(triggerNode.id)}
+            >
+              {data?.hasConnectedTask ? "Add another starting task" : "Add first task"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const renderTaskCard = (taskNode: WorkflowNode, index: number) => {
+    const data = taskNode.data as any
+    const assignedAssistant = data?.assignedAssistant
+
+    return (
+      <Card key={taskNode.id} className="border-border">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="uppercase">Task {index}</Badge>
+              <CardTitle className="text-lg">{data?.name || "Unnamed task"}</CardTitle>
+            </div>
+            <Badge variant="outline">{data?.task_type || "Step"}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            {data?.description || "Define how this step should run."}
+          </p>
+          <div className="rounded-md border p-3 flex items-center gap-3">
+            {assignedAssistant ? (
+              <>
+                <Avatar className="h-9 w-9">
+                  {assignedAssistant.avatar ? (
+                    <AvatarImage src={assignedAssistant.avatar} alt={assignedAssistant.name} />
+                  ) : (
+                    <AvatarFallback>{getInitials(assignedAssistant.name)}</AvatarFallback>
+                  )}
+                </Avatar>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">{assignedAssistant.name}</p>
+                  <p className="text-xs text-muted-foreground">Assigned agent</p>
+                </div>
+                <Button variant="ghost" size="sm" onClick={() => onAssignAgent(data?.workflow_task_id)}>
+                  Change
+                </Button>
+              </>
+            ) : (
+              <div className="flex flex-col gap-2 w-full">
+                <p className="text-sm text-muted-foreground">
+                  Assign an agent to run this task.
+                </p>
+                <Button size="sm" onClick={() => onAssignAgent(data?.workflow_task_id)}>
+                  Choose agent
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button variant="outline" onClick={() => onConfigureTask(data?.workflow_task_id)}>
+              Configure task
+            </Button>
+            <Button variant="ghost" onClick={() => onAddTask(taskNode.id)}>
+              Add next task
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (triggerNodes.length === 0) {
+    return (
+      <div className="flex h-full flex-col justify-center gap-6 p-6 text-center">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">Create your first workflow</h2>
+          <p className="text-sm text-muted-foreground">
+            Start by choosing when the automation should run. We will guide you through adding each step.
+          </p>
+        </div>
+        <Button size="lg" onClick={onAddTrigger}>
+          Configure trigger
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-6 p-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase text-muted-foreground">Step 1</p>
+          <h2 className="text-xl font-semibold">Configure your trigger</h2>
+          <p className="text-sm text-muted-foreground">
+            Decide how this workflow should begin. You can always come back to tweak the trigger.
+          </p>
+        </div>
+        {triggerNodes.map((trigger) => renderTriggerCard(trigger))}
+
+        <Separator className="my-6" />
+
+        <div className="space-y-2">
+          <p className="text-xs uppercase text-muted-foreground">Step 2</p>
+          <h2 className="text-xl font-semibold">Build your task sequence</h2>
+          <p className="text-sm text-muted-foreground">
+            Add steps one at a time. We will keep them in the order you create them.
+          </p>
+        </div>
+
+        {sequences.map((sequence, idx) => (
+          <div key={`sequence-${sequence[0]?.id || idx}`} className="space-y-4">
+            {sequence
+              .filter((node) => node.type === "task")
+              .map((node, taskIndex) => renderTaskCard(node, taskIndex + 1))}
+            {sequence.every((node) => node.type !== "task") && (
+              <Button variant="outline" onClick={() => onAddTask(sequence[0]?.id || "")}
+                className={cn("w-full", !sequence[0] && "hidden")}
+              >
+                Add first task
+              </Button>
+            )}
+          </div>
+        ))}
+
+        {looseTasks.length > 0 && (
+          <div className="space-y-4">
+            <p className="text-sm font-medium">Unlinked tasks</p>
+            {looseTasks.map((task, taskIndex) => renderTaskCard(task, taskIndex + 1))}
+          </div>
+        )}
+
+        {taskNodes.length === 0 && (
+          <Button variant="outline" onClick={() => onAddTask(triggerNodes[0]?.id || "")}>
+            Add first task
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/workflows/tasks/TaskSelectionSheet.tsx
+++ b/components/workflows/tasks/TaskSelectionSheet.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { SiOpenai } from "react-icons/si"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { TASK_OPTIONS, TaskOption } from "./TaskSidebar"
+
+interface TaskSelectionSheetProps {
+  open: boolean
+  onOpenChange: (value: boolean) => void
+  onTaskSelect: (task: TaskOption) => void
+}
+
+export function TaskSelectionSheet({
+  open,
+  onOpenChange,
+  onTaskSelect,
+}: TaskSelectionSheetProps) {
+  const handleSelect = (task: TaskOption) => {
+    onTaskSelect(task)
+    onOpenChange(false)
+  }
+
+  const renderButton = (task: TaskOption) => (
+    <Button
+      key={task.type}
+      variant="outline"
+      className="w-full justify-start gap-3 py-6"
+      onClick={() => handleSelect(task)}
+    >
+      <div className="h-10 w-10 rounded-md bg-primary/10 text-primary grid place-items-center">
+        <SiOpenai className="h-5 w-5" />
+      </div>
+      <div className="flex flex-col items-start text-left">
+        <span className="text-base font-medium leading-none">{task.label}</span>
+        <span className="text-xs text-muted-foreground mt-1">{task.description}</span>
+      </div>
+    </Button>
+  )
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[75vh] overflow-y-auto">
+        <SheetHeader className="text-left">
+          <SheetTitle>Select task type</SheetTitle>
+          <SheetDescription>
+            Pick the type of automation step to add next in your workflow.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="mt-6 space-y-4">
+          {TASK_OPTIONS.map((task) => renderButton(task))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export type { TaskOption }

--- a/components/workflows/tasks/TaskSidebar.tsx
+++ b/components/workflows/tasks/TaskSidebar.tsx
@@ -5,13 +5,13 @@ import { SiOpenai } from "react-icons/si";
 import { Sidebar, SidebarContent } from "@/components/ui/sidebar";
 import { X } from "lucide-react";
 
-interface TaskOption {
+export interface TaskOption {
   type: TaskType;
   label: string;
   description: string;
 }
 
-const AI_TASKS: TaskOption[] = [
+export const TASK_OPTIONS: TaskOption[] = [
   {
     type: "ai_task",
     label: "AI Task",
@@ -51,15 +51,15 @@ export function TaskSidebar({
         <div className="px-4">
           <div
             className="flex cursor-pointer items-start gap-3 rounded-md border p-3 hover:bg-muted/50"
-            onClick={() => onTaskSelect(AI_TASKS[0])}
+            onClick={() => onTaskSelect(TASK_OPTIONS[0])}
           >
             <div className="h-8 w-8 rounded-md bg-primary/10 text-primary grid place-items-center">
               <SiOpenai className="h-4 w-4" />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm font-medium">{AI_TASKS[0].label}</span>
+              <span className="text-sm font-medium">{TASK_OPTIONS[0].label}</span>
               <span className="text-xs text-muted-foreground">
-                {AI_TASKS[0].description}
+                {TASK_OPTIONS[0].description}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add mobile state management so task configuration opens from the workflow wizard
- reuse the existing task modal and streaming test logic when editing tasks on mobile

## Testing
- pnpm run lint *(fails: numerous pre-existing lint errors in unrelated files)*
- pnpm run build *(fails: cannot download Inter font in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b0db05a08331b0b30fca3f10aa1f