### PR TITLE
docs: add comprehensive user tutorials

### DIFF
--- a/docs/tutorials/01-overview.mdx
+++ b/docs/tutorials/01-overview.mdx
@@ -1,0 +1,42 @@
+# AffinityBots Platform Overview
+
+AffinityBots pairs a Next.js workspace with LangGraph automations so teams can create, launch, and refine AI agents without leaving the browser. This overview explains the product pillars, environments, and terminology that appear throughout the tutorials. Use it as a map before diving into specific workflows.
+
+## Product Pillars
+
+1. **Agents** – Custom AI teammates you describe once and redeploy across channels. Each agent inherits a system prompt, chosen model, optional memory, knowledge uploads, and a tool belt of MCP integrations. The agent dashboard and chat surfaces consolidate every conversation thread.
+2. **Workflows** – Visual automations that orchestrate triggers, agent tasks, and tool hand-offs. Flow diagrams are built with drag-and-drop nodes, then executed manually or through configured triggers.
+3. **Tools & Integrations** – Managed MCP servers that connect AffinityBots to services such as Google, Slack, HubSpot, or your own custom endpoints. Tools are configured once and selectively enabled per agent or workflow task.
+4. **Knowledge & Memory** – Domain files, notes, or structured data you upload to specialize an agent, plus optional long-term memory so recurring conversations stay contextual.
+5. **Analytics & Activity** – Dashboard cards summarize agent counts, workflow usage, response health, and recent activity so you can track adoption at a glance.
+
+> **Screenshot prompt:** Include your homepage or hero screenshot here to introduce the visual brand.
+
+## Application Surfaces
+
+- **Marketing site** – The landing page highlights the value proposition, feature list, and integrations prospects expect before signing in. Links jump to early access, pitch deck, and policy pages.
+- **Authenticated workspace** – Once a user signs in, navigation pivots to the dashboard, agents, workflows, and tools sections. Tutorial tours auto-launch the first time a user visits a key surface to accelerate onboarding.
+- **API endpoints** – Next.js server routes back features like early-access enrollment, agent CRUD, prompt enhancement, knowledge uploads, Smithery directory search, and MCP authentication. They ensure UI actions persist to Supabase and notify teams via Resend email.
+
+## Core Entities
+
+| Entity | Description | Where it appears |
+| --- | --- | --- |
+| Agent | A configured assistant with prompt, model, tools, memory, and knowledge settings. | Agent list, agent detail header, workflow task assignment. |
+| Thread | A conversation between a user and a specific agent. | Chat container sidebar. |
+| Workflow | A saved automation graph tying triggers to agent tasks. | Workflows list, builder, execution history. |
+| MCP Server | Integration endpoint conforming to the Model Context Protocol. | Tools page, Tool Selector, agent configuration. |
+| Knowledge Source | File or dataset uploaded for retrieval. | Agent creation knowledge queue, agent configuration knowledge tab. |
+
+## Key Roles & Permissions
+
+- **Workspace owners** control Supabase accounts, configure tools, create agents, and share workflows.
+- **Invited teammates** inherit the same workspace data (agents, tools, workflows) but respect Supabase row-level security to prevent cross-tenant access.
+- **Prospective users** begin on the public site and can submit an early-access request. Admin notifications and applicant confirmation emails are handled automatically.
+
+## Getting Help
+
+- **In-app tours** trigger the first time a user opens the dashboard, new agent form, agent chat, configuration drawer, or tools catalog. The tours outline the same steps documented here.
+- **Support** links in the footer direct people to contact support@affinitybots.com, legal policies, and social channels.
+
+Continue to the next tutorials for actionable walkthroughs of each surface.

--- a/docs/tutorials/02-dashboard.mdx
+++ b/docs/tutorials/02-dashboard.mdx
@@ -1,0 +1,44 @@
+# Navigating the Workspace Dashboard
+
+The dashboard is the first screen signed-in users see. It summarizes activity and exposes shortcuts for building new agents, workflows, and tools. This guide walks through each panel so you can interpret metrics and launch deeper tasks confidently.
+
+## Access & Layout
+
+1. Sign in to AffinityBots and you will be redirected to `/dashboard`.
+2. The header contains quick actions for creating agents or workflows and selecting a date filter for the stats cards.
+3. Below the header, the page arranges four content zones: summary cards, recent agents, configured tools, and activity/workflow feeds.
+
+> **Screenshot prompt:** Add your full dashboard screenshot here to show the layout before diving into each card.
+
+## Summary Cards
+
+- **Total Agents** reports how many assistants exist in the workspace. The number is derived from Supabase `user_assistants` records and reflects shared ownership.
+- **Total Workflows** counts workflow graphs tied to the current user. Use it to confirm that automation coverage is growing.
+- **Success Rate** and **Avg Response Time** surface system health metrics. These are placeholders today but exist so future telemetry can slot in without redesigning the UI.
+
+## Agents Panel
+
+- Lists the three most recently created agents with avatar, model, description snippet, and enabled tool badges.
+- Clicking an agent opens its dedicated chat workspace.
+- The `Create Agent` button appears if the list is empty, while a “View all agents” link shows when more than three exist.
+- Tool badges display official logos when available, otherwise fall back to emoji so you can quickly scan which integrations each agent uses.
+
+## Tools Panel
+
+- Shows up to three MCP servers you have configured. Status badges indicate whether each integration is enabled for the workspace.
+- The “Configure Tools” button guides first-time users to the tools catalog, while a “View all tools” link appears when more integrations are connected.
+- Logo fetching combines official assets with Smithery lookups to keep cards recognizable even when screenshots are missing.
+
+## Activity & Workflow Feeds
+
+- **Latest Workflows** highlights recently created or updated graphs, including status chips (Active, Inactive) and last modified dates.
+- **Recent Activity** condenses logs into human-readable events (workflow completed, agent created, errors). Colored badges differentiate successful actions from warnings.
+- Empty states point users to create their first workflow or agent so the page never feels like a dead end.
+
+## Dashboard Tips
+
+- Use the “New Agent” or “New Workflow” buttons from the dashboard header—tutorial tours highlight them for onboarding.
+- If logos fail to load because of network issues, the UI still provides textual fallback names so you can continue configuring agents.
+- Sample activity is generated when a workspace has no history yet, helping stakeholders envision value from day one.
+
+> **Screenshot prompt:** Capture close-up screenshots of the Agents panel and Activity feed to illustrate real data.

--- a/docs/tutorials/03-agents.mdx
+++ b/docs/tutorials/03-agents.mdx
@@ -1,0 +1,54 @@
+# Building and Collaborating with Agents
+
+Agents are the heart of AffinityBots. This walkthrough covers the full lifecycle—from creating a new assistant with optional tooling and knowledge, to managing ongoing conversations and configuration updates.
+
+## Agents Home
+
+- Navigate to `/agents` to see every assistant you have access to.
+- The page lists cards containing avatar initials or custom imagery, description snippets, model labels, and the MCP servers enabled for that agent.
+- Hovering reveals a delete icon; deleting an agent removes it from all workflows, so confirm before proceeding.
+- Use the “Create Agent” button in the header to open the creation form.
+
+> **Screenshot prompt:** Capture a grid of agent cards to show how models and tool badges appear.
+
+## Creating a New Agent
+
+1. Click **Create Agent** to open the builder at `/agents/new`.
+2. Optionally supply a **Name**—if left blank, AffinityBots will auto-generate a creative title.
+3. In the **Describe Your AI Agent** box, explain what the assistant should do. This required description becomes the core of the system prompt.
+4. Use the **Enhance** button to run the description through the built-in prompt improvement API.
+5. Optionally pick a **template pill** to populate the description with a best-practice starting point.
+6. Expand **Add Tools** to open the Tool Selector. Toggle any MCP servers you have already configured. (You must configure a server before enabling it here.)
+7. Expand **Add Knowledge** to queue document uploads. Drag-and-drop or browse for PDFs, text, spreadsheets, HTML, JSON, or Markdown. Files upload after the agent is successfully created.
+8. Submit the form. The UI displays a creation dialog while the backend provisions the agent, uploads knowledge, and persists metadata.
+
+> **Screenshot prompt:** Showcase the Create Agent form with the Tools and Knowledge accordions expanded.
+
+## Knowledge Upload Status
+
+- After creation, queued files upload in sequence. Each file row displays queued, uploading, success, or error states.
+- Successful uploads are added to the agent’s knowledge base configuration; failures surface the error message so you can retry later.
+
+## Agent Detail Workspace
+
+- Selecting an agent opens a full-screen workspace with a header summary and a chat area.
+- The header displays the model badge, memory/knowledge badges when enabled, and tool pills with logos where available.
+- Use the **Configure** button to adjust prompt, tools, knowledge, and memory settings via dedicated tabs.
+- The back button returns you to the agent list without losing chat context.
+
+> **Screenshot prompt:** Include a header close-up highlighting badges and the Configure button.
+
+## Conversational Threads
+
+- The left sidebar lists conversation threads for the current agent. Start a **New Chat** to create a fresh thread.
+- Each thread can be renamed or deleted via the overflow menu. Deleting a thread asks for confirmation and, if it was active, switches to a new blank thread.
+- The main chat area supports streaming replies, attachments, and tutorial cues for first-time users.
+- Tours automatically highlight the chat viewport, attachment controls, new chat button, and Configure action the first time a user lands here.
+
+> **Screenshot prompt:** Capture the chat layout with sidebar open and a conversation in progress.
+
+## Configuration Best Practices
+
+- Keep the primary description focused on the agent’s responsibilities; use knowledge uploads for reference materials rather than giant prompts.
+- Enable memory when you want the agent to remember user-specific details between sessions, and disable it for compliance-sensitive roles.
+- Review tool access regularly. Disabling unused MCP servers reduces the chance of misfired actions and clarifies capabilities for teammates.

--- a/docs/tutorials/04-tools-and-integrations.mdx
+++ b/docs/tutorials/04-tools-and-integrations.mdx
@@ -1,0 +1,44 @@
+# Connecting Tools and Integrations
+
+Tools expand what agents and workflows can accomplish. AffinityBots ships with official MCP servers, supports the Smithery marketplace, and lets you add bespoke endpoints. This tutorial explains how to browse, configure, and attach tools to your agents.
+
+## Tools Catalog Overview
+
+1. Open `/tools` to browse available MCP servers.
+2. Use the search bar to filter by keyword; results update after a short debounce so you can iterate quickly.
+3. Filter chips let you switch between **All**, **Official**, and **Smithery** sources. Official servers are curated by the team, while Smithery entries come from the Smithery API.
+4. Pagination controls (first/prev/next/last) help you navigate large directories without overwhelming the UI.
+5. A floating **Add MCP Server** button opens the modal for adding your own integration.
+
+> **Screenshot prompt:** Capture the tools catalog with search, filters, and pagination visible.
+
+## Server Cards
+
+- **Official Server Card** – Displays brand logo, description, and a badge indicating the source. Connect buttons deep link into configuration pages.
+- **Smithery Server Card** – Pulls metadata from Smithery and fetches missing logos using the bulk icon endpoint. Cards show security badges when Smithery verifies a scan.
+- **Custom Server Card** – Lists servers you or your teammates added manually. Use these when no catalog entry exists.
+
+Each card indicates whether a server is already configured. Configured servers show a toggle so you can quickly enable or disable them for the workspace.
+
+## Adding a Custom MCP Server
+
+1. Click **Add MCP Server**.
+2. Enter the qualified name (e.g., `github`, `zapier`, or a custom slug) and the server URL.
+3. Click **Detect auth** to let AffinityBots discover whether the server requires OAuth. The app uses `/api/mcp/discover` with a callback URL to test the endpoint.
+4. If OAuth is required, use **Connect (OAuth)** to start the handshake. Otherwise choose **Save** to register the server with no additional auth.
+5. After saving, the server appears in your configured list and is eligible for agent enablement.
+
+> **Screenshot prompt:** Add a modal screenshot showing the custom server form.
+
+## Tool Selector Inside the Agent Builder
+
+- When you create or edit an agent, expand **Add Tools** to open the Tool Selector.
+- The selector groups servers into **Configured** and **Available** sections, ensuring you only enable services that have working credentials.
+- Status badges identify whether a server is official, from Smithery, or custom. Additional badges show configuration state, security verification, and whether the server is local or remote.
+- Switches next to each configured server toggle usage for the current agent.
+
+## Maintaining Integrations
+
+- Refresh the tools page if icons appear missing; cached logos expire after 24 hours to keep branding current.
+- For Smithery sources that require additional credentials, visit the linked configuration routes to enter API keys or secrets.
+- Disable unused servers to simplify the Tool Selector and help teammates understand which integrations are production-ready.

--- a/docs/tutorials/05-workflows.mdx
+++ b/docs/tutorials/05-workflows.mdx
@@ -1,0 +1,45 @@
+# Designing Automated Workflows
+
+Workflows orchestrate agents, triggers, and tasks into repeatable automations. This tutorial explains how to review existing workflows, build new graphs, and execute or maintain them over time.
+
+## Exploring Saved Workflows
+
+- Visit `/workflows` to see the workflows you own. Cards show the workflow name, last run time, node count, and avatars for assigned agents.
+- Hovering reveals a delete button—use it carefully because removal is permanent and cancels all downstream automations.
+- The page includes an empty state prompting you to create your first workflow, complete with a call-to-action button.
+
+> **Screenshot prompt:** Capture the workflows grid, including the card hover state if possible.
+
+## Creating or Editing a Workflow
+
+1. Click **Create New Workflow** (or open an existing workflow) to load the visual builder.
+2. The canvas uses React Flow, so you can drag nodes around freely. Pan and zoom to organize large graphs.
+3. Use the header to rename the workflow, switch between Editor and Executions modes, and trigger manual runs.
+4. Add nodes via the Task Sidebar or the mobile-friendly Task Selection Sheet. Nodes represent triggers, agent tasks, or tool actions.
+5. Connect nodes by dragging edges between handles to define execution order.
+6. Autosave keeps drafts up to date; the builder compares snapshots so redundant writes are avoided.
+
+> **Screenshot prompt:** Include the workflow canvas with a few nodes connected.
+
+## Assigning Agents and Configuring Tasks
+
+- Each task can be assigned to an agent via the **Assign Agent** action. A modal lists all available agents with avatars so you can pick the right teammate.
+- Task configuration panels let you customize inputs, outputs, and other settings depending on the task type.
+- Triggers can be added once a workflow is saved. Configure them to start the workflow on schedules, webhooks, or other events.
+
+## Executing a Workflow
+
+- Click **Run Workflow** from the header to execute manually.
+- The execution manager coordinates status updates and surfaces success or failure notifications via toast messages.
+- Switch to the **Executions** tab to review past runs once telemetry is persisted.
+
+## Mobile Builder Experience
+
+- The builder detects smaller screens and switches to a guided wizard (WorkflowMobileWizard) that steps through node creation without requiring drag-and-drop.
+- Tasks can still be assigned agents and configured through this wizard, making on-the-go edits possible.
+
+## Maintenance Tips
+
+- Revisit workflows periodically to ensure node configurations still align with business rules, especially after updating agent prompts or tools.
+- Use descriptive names for tasks and workflows so team members understand each automation at a glance.
+- Clean up unused workflows to keep the dashboard metrics accurate and reduce clutter in the activity feed.


### PR DESCRIPTION
## Summary
- add an AffinityBots overview tutorial covering platform pillars and terminology
- document dashboard, agent management, tools, and workflow automation in new MDX guides
- include screenshot prompts to pair existing captures with each walkthrough

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8561fe73083319c0044ec1d21d57f